### PR TITLE
Add multi-recipe cost comparison feature

### DIFF
--- a/frontend/src/components/MultiRecipeCostComparison.tsx
+++ b/frontend/src/components/MultiRecipeCostComparison.tsx
@@ -1,0 +1,511 @@
+import React, { useState, useEffect } from 'react';
+import { apiService } from '../services/api';
+import { Recipe, RecipeDetail, Ingredient, PurchaseHistory, EggMaster } from '../types';
+
+interface MultiRecipeCostComparisonProps {
+  recipes: Recipe[];
+  allRecipeDetails: { [recipeId: number]: RecipeDetail[] };
+}
+
+interface RecipeCostSummary {
+  recipe: Recipe;
+  totalCosts: {
+    current: number;
+    min: number;
+    max: number;
+    avg_3m: number;
+    avg_6m: number;
+  };
+  perUnitCosts: {
+    current: number;
+    min: number;
+    max: number;
+    avg_3m: number;
+    avg_6m: number;
+  };
+  ingredientCosts: IngredientCost[];
+  hasData: boolean;
+}
+
+interface IngredientCost {
+  ingredient_id: number;
+  ingredient_name: string;
+  usage_amount: string;
+  usage_unit: string;
+  egg_type?: string;
+  cost_current?: number;
+  cost_min?: number;
+  cost_max?: number;
+  cost_avg_3m?: number;
+  cost_avg_6m?: number;
+}
+
+const MultiRecipeCostComparison: React.FC<MultiRecipeCostComparisonProps> = ({ 
+  recipes, 
+  allRecipeDetails 
+}) => {
+  const [recipeCostSummaries, setRecipeCostSummaries] = useState<RecipeCostSummary[]>([]);
+  const [ingredients, setIngredients] = useState<Ingredient[]>([]);
+  const [purchaseHistory, setPurchaseHistory] = useState<PurchaseHistory[]>([]);
+  const [eggMasters, setEggMasters] = useState<EggMaster[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string>('');
+
+  useEffect(() => {
+    const fetchDataAndCalculate = async () => {
+      if (recipes.length === 0) return;
+      
+      try {
+        setError('');
+        setLoading(true);
+
+        const [ingredientsData, purchaseHistoryData, eggMasterData] = await Promise.all([
+          apiService.getIngredients(),
+          apiService.getPurchaseHistory(),
+          apiService.getEggMasters()
+        ]);
+
+        setIngredients(ingredientsData);
+        setPurchaseHistory(purchaseHistoryData);
+        setEggMasters(eggMasterData);
+
+        const summaries = await Promise.all(
+          recipes.map(async (recipe) => {
+            const recipeDetails = allRecipeDetails[recipe.recipe_id] || [];
+            const costSummary = await calculateRecipeCosts(
+              recipe,
+              recipeDetails,
+              ingredientsData,
+              purchaseHistoryData,
+              eggMasterData
+            );
+            return costSummary;
+          })
+        );
+
+        setRecipeCostSummaries(summaries);
+      } catch (error) {
+        console.error('Error calculating costs:', error);
+        setError('コスト計算中にエラーが発生しました。');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchDataAndCalculate();
+  }, [recipes, allRecipeDetails]);
+
+  const calculateRecipeCosts = async (
+    recipe: Recipe,
+    recipeDetails: RecipeDetail[],
+    ingredientsData: Ingredient[],
+    purchaseHistoryData: PurchaseHistory[],
+    eggMasterData: EggMaster[]
+  ): Promise<RecipeCostSummary> => {
+    const ingredientCosts = await Promise.all(
+      recipeDetails.map(async (detail) => {
+        const ingredient = ingredientsData.find(i => i.ingredient_id === detail.ingredient_id);
+        if (!ingredient) {
+          return null;
+        }
+
+        const purchases = purchaseHistoryData.filter(p => p.ingredient_id === detail.ingredient_id);
+        
+        if (purchases.length === 0) {
+          return {
+            ingredient_id: detail.ingredient_id,
+            ingredient_name: ingredient.recipe_display_name,
+            usage_amount: detail.usage_amount,
+            usage_unit: detail.usage_unit,
+            egg_type: detail.egg_type
+          };
+        }
+
+        const prices = purchases.map(p => {
+          const price = parseFloat(p.price_excluding_tax);
+          const tax = parseFloat(p.tax_rate);
+          const discount = parseFloat(p.discount_rate || '0');
+          return price * (1 - discount) * (1 + tax);
+        });
+
+        const currentPrice = prices[prices.length - 1];
+        const minPrice = Math.min(...prices);
+        const maxPrice = Math.max(...prices);
+
+        const now = new Date();
+        const threeMonthsAgo = new Date(now.getTime() - 90 * 24 * 60 * 60 * 1000);
+        const sixMonthsAgo = new Date(now.getTime() - 180 * 24 * 60 * 60 * 1000);
+
+        const recentPurchases3m = purchases.filter(p => new Date(p.purchase_date) >= threeMonthsAgo);
+        const recentPurchases6m = purchases.filter(p => new Date(p.purchase_date) >= sixMonthsAgo);
+
+        const avg3mPrice = recentPurchases3m.length > 0 
+          ? recentPurchases3m.reduce((sum, p) => {
+              const price = parseFloat(p.price_excluding_tax);
+              const tax = parseFloat(p.tax_rate);
+              const discount = parseFloat(p.discount_rate || '0');
+              return sum + price * (1 - discount) * (1 + tax);
+            }, 0) / recentPurchases3m.length
+          : currentPrice;
+
+        const avg6mPrice = recentPurchases6m.length > 0
+          ? recentPurchases6m.reduce((sum, p) => {
+              const price = parseFloat(p.price_excluding_tax);
+              const tax = parseFloat(p.tax_rate);
+              const discount = parseFloat(p.discount_rate || '0');
+              return sum + price * (1 - discount) * (1 + tax);
+            }, 0) / recentPurchases6m.length
+          : currentPrice;
+
+        let usageInGrams = parseFloat(detail.usage_amount);
+        
+        if (ingredient.recipe_display_name === '卵' && detail.egg_type && eggMasterData.length > 0) {
+          const eggMaster = eggMasterData[0];
+          switch (detail.egg_type) {
+            case 'whole_egg':
+              usageInGrams = usageInGrams * parseFloat(eggMaster.whole_egg_weight);
+              break;
+            case 'egg_white':
+              usageInGrams = usageInGrams * parseFloat(eggMaster.egg_white_weight);
+              break;
+            case 'egg_yolk':
+              usageInGrams = usageInGrams * parseFloat(eggMaster.egg_yolk_weight);
+              break;
+          }
+        } else {
+          switch (detail.usage_unit) {
+            case 'kg':
+              usageInGrams *= 1000;
+              break;
+            case 'ml':
+              break;
+            case 'l':
+              usageInGrams *= 1000;
+              break;
+          }
+        }
+
+        const baseQuantity = ingredient.quantity;
+        const baseUnit = ingredient.quantity_unit;
+        let baseInGrams = baseQuantity;
+
+        switch (baseUnit) {
+          case 'kg':
+            baseInGrams *= 1000;
+            break;
+          case 'ml':
+            break;
+          case 'l':
+            baseInGrams *= 1000;
+            break;
+          case '個':
+            if (ingredient.recipe_display_name === '卵') {
+              baseInGrams = baseQuantity * 50;
+            }
+            break;
+        }
+
+        const ratio = usageInGrams / baseInGrams;
+
+        return {
+          ingredient_id: detail.ingredient_id,
+          ingredient_name: ingredient.recipe_display_name,
+          usage_amount: detail.usage_amount,
+          usage_unit: detail.usage_unit,
+          egg_type: detail.egg_type,
+          cost_current: currentPrice * ratio,
+          cost_min: minPrice * ratio,
+          cost_max: maxPrice * ratio,
+          cost_avg_3m: avg3mPrice * ratio,
+          cost_avg_6m: avg6mPrice * ratio
+        };
+      })
+    );
+
+    const validIngredientCosts = ingredientCosts.filter(Boolean) as IngredientCost[];
+    
+    const totalCosts = validIngredientCosts.reduce(
+      (totals, cost) => ({
+        current: totals.current + (cost.cost_current || 0),
+        min: totals.min + (cost.cost_min || 0),
+        max: totals.max + (cost.cost_max || 0),
+        avg_3m: totals.avg_3m + (cost.cost_avg_3m || 0),
+        avg_6m: totals.avg_6m + (cost.cost_avg_6m || 0)
+      }),
+      { current: 0, min: 0, max: 0, avg_3m: 0, avg_6m: 0 }
+    );
+
+    const perUnitCosts = recipe.yield_per_batch > 0 ? {
+      current: totalCosts.current / recipe.yield_per_batch,
+      min: totalCosts.min / recipe.yield_per_batch,
+      max: totalCosts.max / recipe.yield_per_batch,
+      avg_3m: totalCosts.avg_3m / recipe.yield_per_batch,
+      avg_6m: totalCosts.avg_6m / recipe.yield_per_batch
+    } : { current: 0, min: 0, max: 0, avg_3m: 0, avg_6m: 0 };
+
+    const hasData = validIngredientCosts.some(cost => cost.cost_current !== undefined);
+
+    return {
+      recipe,
+      totalCosts,
+      perUnitCosts,
+      ingredientCosts: validIngredientCosts,
+      hasData
+    };
+  };
+
+  const formatPrice = (price: number) => {
+    return new Intl.NumberFormat('ja-JP', {
+      style: 'currency',
+      currency: 'JPY'
+    }).format(price);
+  };
+
+  const getBestValue = (summaries: RecipeCostSummary[], field: 'current' | 'min' | 'max' | 'avg_3m' | 'avg_6m') => {
+    const values = summaries.filter(s => s.hasData).map(s => s.totalCosts[field]);
+    return values.length > 0 ? Math.min(...values) : null;
+  };
+
+  const getBestPerUnitValue = (summaries: RecipeCostSummary[], field: 'current' | 'min' | 'max' | 'avg_3m' | 'avg_6m') => {
+    const values = summaries.filter(s => s.hasData && s.recipe.yield_per_batch > 0).map(s => s.perUnitCosts[field]);
+    return values.length > 0 ? Math.min(...values) : null;
+  };
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center h-32">
+        <div className="text-sm text-gray-600">レシピ比較データを計算中...</div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded">
+        {error}
+      </div>
+    );
+  }
+
+  const bestTotalCurrent = getBestValue(recipeCostSummaries, 'current');
+  const bestTotalMin = getBestValue(recipeCostSummaries, 'min');
+  const bestTotalMax = getBestValue(recipeCostSummaries, 'max');
+  const bestTotalAvg3m = getBestValue(recipeCostSummaries, 'avg_3m');
+  const bestTotalAvg6m = getBestValue(recipeCostSummaries, 'avg_6m');
+
+  const bestPerUnitCurrent = getBestPerUnitValue(recipeCostSummaries, 'current');
+  const bestPerUnitMin = getBestPerUnitValue(recipeCostSummaries, 'min');
+  const bestPerUnitMax = getBestPerUnitValue(recipeCostSummaries, 'max');
+  const bestPerUnitAvg3m = getBestPerUnitValue(recipeCostSummaries, 'avg_3m');
+  const bestPerUnitAvg6m = getBestPerUnitValue(recipeCostSummaries, 'avg_6m');
+
+  return (
+    <div className="space-y-6">
+      <div className="bg-white shadow sm:rounded-lg">
+        <div className="px-4 py-5 sm:p-6">
+          <h3 className="text-lg leading-6 font-medium text-gray-900 mb-6">
+            レシピ原価比較 ({recipeCostSummaries.length}件)
+          </h3>
+          
+          {/* バッチあたり原価比較 */}
+          <div className="mb-8">
+            <h4 className="text-md font-medium text-gray-700 mb-4">
+              バッチあたり原価比較
+            </h4>
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead className="bg-gray-50">
+                  <tr>
+                    <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">
+                      レシピ名
+                    </th>
+                    <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">
+                      バッチサイズ
+                    </th>
+                    <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">
+                      現在価格
+                    </th>
+                    <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">
+                      最安値
+                    </th>
+                    <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">
+                      最高値
+                    </th>
+                    <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">
+                      3ヶ月平均
+                    </th>
+                    <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">
+                      6ヶ月平均
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="bg-white divide-y divide-gray-200">
+                  {recipeCostSummaries.map((summary) => (
+                    <tr key={summary.recipe.recipe_id} className="hover:bg-gray-50">
+                      <td className="px-4 py-2 whitespace-nowrap">
+                        <div className="text-sm font-medium text-gray-900">
+                          {summary.recipe.recipe_name}
+                        </div>
+                      </td>
+                      <td className="px-4 py-2 whitespace-nowrap text-sm text-gray-900">
+                        {summary.recipe.batch_size} {summary.recipe.batch_unit}
+                      </td>
+                      <td className={`px-4 py-2 whitespace-nowrap text-sm ${
+                        summary.hasData && summary.totalCosts.current === bestTotalCurrent 
+                          ? 'text-green-600 font-bold' 
+                          : 'text-gray-900'
+                      }`}>
+                        {summary.hasData ? formatPrice(summary.totalCosts.current) : '-'}
+                      </td>
+                      <td className={`px-4 py-2 whitespace-nowrap text-sm ${
+                        summary.hasData && summary.totalCosts.min === bestTotalMin 
+                          ? 'text-green-600 font-bold' 
+                          : 'text-gray-900'
+                      }`}>
+                        {summary.hasData ? formatPrice(summary.totalCosts.min) : '-'}
+                      </td>
+                      <td className={`px-4 py-2 whitespace-nowrap text-sm ${
+                        summary.hasData && summary.totalCosts.max === bestTotalMax 
+                          ? 'text-green-600 font-bold' 
+                          : 'text-gray-900'
+                      }`}>
+                        {summary.hasData ? formatPrice(summary.totalCosts.max) : '-'}
+                      </td>
+                      <td className={`px-4 py-2 whitespace-nowrap text-sm ${
+                        summary.hasData && summary.totalCosts.avg_3m === bestTotalAvg3m 
+                          ? 'text-green-600 font-bold' 
+                          : 'text-gray-900'
+                      }`}>
+                        {summary.hasData ? formatPrice(summary.totalCosts.avg_3m) : '-'}
+                      </td>
+                      <td className={`px-4 py-2 whitespace-nowrap text-sm ${
+                        summary.hasData && summary.totalCosts.avg_6m === bestTotalAvg6m 
+                          ? 'text-green-600 font-bold' 
+                          : 'text-gray-900'
+                      }`}>
+                        {summary.hasData ? formatPrice(summary.totalCosts.avg_6m) : '-'}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          {/* 単位あたり原価比較 */}
+          <div className="mb-8">
+            <h4 className="text-md font-medium text-gray-700 mb-4">
+              単位あたり原価比較
+            </h4>
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead className="bg-gray-50">
+                  <tr>
+                    <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">
+                      レシピ名
+                    </th>
+                    <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">
+                      出来高
+                    </th>
+                    <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">
+                      現在価格
+                    </th>
+                    <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">
+                      最安値
+                    </th>
+                    <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">
+                      最高値
+                    </th>
+                    <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">
+                      3ヶ月平均
+                    </th>
+                    <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">
+                      6ヶ月平均
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="bg-white divide-y divide-gray-200">
+                  {recipeCostSummaries.map((summary) => (
+                    <tr key={summary.recipe.recipe_id} className="hover:bg-gray-50">
+                      <td className="px-4 py-2 whitespace-nowrap">
+                        <div className="text-sm font-medium text-gray-900">
+                          {summary.recipe.recipe_name}
+                        </div>
+                      </td>
+                      <td className="px-4 py-2 whitespace-nowrap text-sm text-gray-900">
+                        {summary.recipe.yield_per_batch > 0 
+                          ? `${summary.recipe.yield_per_batch} ${summary.recipe.yield_unit}`
+                          : '-'
+                        }
+                      </td>
+                      <td className={`px-4 py-2 whitespace-nowrap text-sm ${
+                        summary.hasData && summary.recipe.yield_per_batch > 0 && summary.perUnitCosts.current === bestPerUnitCurrent 
+                          ? 'text-green-600 font-bold' 
+                          : 'text-gray-900'
+                      }`}>
+                        {summary.hasData && summary.recipe.yield_per_batch > 0 
+                          ? formatPrice(summary.perUnitCosts.current) 
+                          : '-'
+                        }
+                      </td>
+                      <td className={`px-4 py-2 whitespace-nowrap text-sm ${
+                        summary.hasData && summary.recipe.yield_per_batch > 0 && summary.perUnitCosts.min === bestPerUnitMin 
+                          ? 'text-green-600 font-bold' 
+                          : 'text-gray-900'
+                      }`}>
+                        {summary.hasData && summary.recipe.yield_per_batch > 0 
+                          ? formatPrice(summary.perUnitCosts.min) 
+                          : '-'
+                        }
+                      </td>
+                      <td className={`px-4 py-2 whitespace-nowrap text-sm ${
+                        summary.hasData && summary.recipe.yield_per_batch > 0 && summary.perUnitCosts.max === bestPerUnitMax 
+                          ? 'text-green-600 font-bold' 
+                          : 'text-gray-900'
+                      }`}>
+                        {summary.hasData && summary.recipe.yield_per_batch > 0 
+                          ? formatPrice(summary.perUnitCosts.max) 
+                          : '-'
+                        }
+                      </td>
+                      <td className={`px-4 py-2 whitespace-nowrap text-sm ${
+                        summary.hasData && summary.recipe.yield_per_batch > 0 && summary.perUnitCosts.avg_3m === bestPerUnitAvg3m 
+                          ? 'text-green-600 font-bold' 
+                          : 'text-gray-900'
+                      }`}>
+                        {summary.hasData && summary.recipe.yield_per_batch > 0 
+                          ? formatPrice(summary.perUnitCosts.avg_3m) 
+                          : '-'
+                        }
+                      </td>
+                      <td className={`px-4 py-2 whitespace-nowrap text-sm ${
+                        summary.hasData && summary.recipe.yield_per_batch > 0 && summary.perUnitCosts.avg_6m === bestPerUnitAvg6m 
+                          ? 'text-green-600 font-bold' 
+                          : 'text-gray-900'
+                      }`}>
+                        {summary.hasData && summary.recipe.yield_per_batch > 0 
+                          ? formatPrice(summary.perUnitCosts.avg_6m) 
+                          : '-'
+                        }
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          {recipeCostSummaries.every(s => !s.hasData) && (
+            <div className="text-center py-8">
+              <p className="text-gray-500">
+                原価比較を行うには仕入れ履歴が必要です。
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MultiRecipeCostComparison;

--- a/frontend/src/pages/CostCalculationPage.tsx
+++ b/frontend/src/pages/CostCalculationPage.tsx
@@ -2,11 +2,17 @@ import React, { useState, useEffect } from 'react';
 import { apiService } from '../services/api';
 import { Recipe, RecipeDetail } from '../types';
 import CostCalculator from '../components/CostCalculator';
+import MultiRecipeCostComparison from '../components/MultiRecipeCostComparison';
+
+type ViewMode = 'selection' | 'single' | 'comparison';
 
 const CostCalculationPage: React.FC = () => {
   const [recipes, setRecipes] = useState<Recipe[]>([]);
   const [selectedRecipe, setSelectedRecipe] = useState<Recipe | null>(null);
+  const [selectedRecipes, setSelectedRecipes] = useState<Recipe[]>([]);
   const [recipeDetails, setRecipeDetails] = useState<RecipeDetail[]>([]);
+  const [allRecipeDetails, setAllRecipeDetails] = useState<{ [recipeId: number]: RecipeDetail[] }>({});
+  const [viewMode, setViewMode] = useState<ViewMode>('selection');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string>('');
 
@@ -31,6 +37,47 @@ const CostCalculationPage: React.FC = () => {
       const details = await apiService.getRecipeDetails(recipe.recipe_id);
       setSelectedRecipe(recipe);
       setRecipeDetails(details);
+      setViewMode('single');
+    } catch (error) {
+      console.error('Error fetching recipe details:', error);
+      setError('レシピ詳細の取得中にエラーが発生しました。');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleMultiRecipeToggle = (recipe: Recipe) => {
+    setSelectedRecipes(prev => {
+      const isSelected = prev.some(r => r.recipe_id === recipe.recipe_id);
+      if (isSelected) {
+        return prev.filter(r => r.recipe_id !== recipe.recipe_id);
+      } else {
+        return [...prev, recipe];
+      }
+    });
+  };
+
+  const handleCompareRecipes = async () => {
+    if (selectedRecipes.length < 2) {
+      setError('比較するには2つ以上のレシピを選択してください。');
+      return;
+    }
+
+    setLoading(true);
+    setError('');
+    try {
+      const detailsPromises = selectedRecipes.map(recipe => 
+        apiService.getRecipeDetails(recipe.recipe_id)
+      );
+      const allDetails = await Promise.all(detailsPromises);
+      
+      const detailsMap: { [recipeId: number]: RecipeDetail[] } = {};
+      selectedRecipes.forEach((recipe, index) => {
+        detailsMap[recipe.recipe_id] = allDetails[index];
+      });
+      
+      setAllRecipeDetails(detailsMap);
+      setViewMode('comparison');
     } catch (error) {
       console.error('Error fetching recipe details:', error);
       setError('レシピ詳細の取得中にエラーが発生しました。');
@@ -41,7 +88,10 @@ const CostCalculationPage: React.FC = () => {
 
   const clearSelection = () => {
     setSelectedRecipe(null);
+    setSelectedRecipes([]);
     setRecipeDetails([]);
+    setAllRecipeDetails({});
+    setViewMode('selection');
     setError('');
   };
 
@@ -49,14 +99,24 @@ const CostCalculationPage: React.FC = () => {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold text-gray-900">原価計算</h1>
-        {selectedRecipe && (
-          <button
-            onClick={clearSelection}
-            className="px-4 py-2 text-sm bg-gray-200 text-gray-700 rounded hover:bg-gray-300 transition-colors"
-          >
-            レシピ選択に戻る
-          </button>
-        )}
+        <div className="flex items-center space-x-3">
+          {viewMode !== 'selection' && (
+            <button
+              onClick={clearSelection}
+              className="px-4 py-2 text-sm bg-gray-200 text-gray-700 rounded hover:bg-gray-300 transition-colors"
+            >
+              レシピ選択に戻る
+            </button>
+          )}
+          {viewMode === 'selection' && selectedRecipes.length >= 2 && (
+            <button
+              onClick={handleCompareRecipes}
+              className="px-4 py-2 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors"
+            >
+              選択したレシピを比較 ({selectedRecipes.length}件)
+            </button>
+          )}
+        </div>
       </div>
 
       {error && (
@@ -65,12 +125,27 @@ const CostCalculationPage: React.FC = () => {
         </div>
       )}
 
-      {!selectedRecipe ? (
+      {viewMode === 'selection' && (
         <div className="bg-white shadow sm:rounded-lg">
           <div className="px-4 py-5 sm:p-6">
-            <h3 className="text-lg leading-6 font-medium text-gray-900 mb-4">
-              原価計算するレシピを選択してください
-            </h3>
+            <div className="flex items-center justify-between mb-4">
+              <h3 className="text-lg leading-6 font-medium text-gray-900">
+                レシピを選択してください
+              </h3>
+              <div className="text-sm text-gray-600">
+                {selectedRecipes.length > 0 && (
+                  <span>選択中: {selectedRecipes.length}件</span>
+                )}
+              </div>
+            </div>
+            
+            <div className="mb-4 p-3 bg-blue-50 rounded-md">
+              <p className="text-sm text-blue-700">
+                💡 <strong>使い方:</strong> 
+                クリックで単一レシピの詳細原価計算、
+                チェックボックスで複数選択して比較分析ができます
+              </p>
+            </div>
             
             {recipes.length === 0 ? (
               <div className="text-center py-8">
@@ -80,37 +155,59 @@ const CostCalculationPage: React.FC = () => {
               </div>
             ) : (
               <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-                {recipes.map((recipe) => (
-                  <div
-                    key={recipe.recipe_id}
-                    onClick={() => handleRecipeSelect(recipe)}
-                    className="cursor-pointer p-4 border border-gray-200 rounded-lg hover:shadow-lg hover:border-blue-300 transition-all"
-                  >
-                    <h4 className="text-lg font-semibold text-gray-900 mb-2">
-                      {recipe.recipe_name}
-                    </h4>
-                    <div className="space-y-1 text-sm text-gray-600">
-                      <p>バッチサイズ: {recipe.batch_size} {recipe.batch_unit}</p>
-                      {recipe.yield_per_batch > 0 && (
-                        <p>出来高: {recipe.yield_per_batch} {recipe.yield_unit}</p>
-                      )}
-                      <p>複雑度: {recipe.complexity_level}</p>
-                      {recipe.category && (
-                        <p>カテゴリー: {recipe.category}</p>
-                      )}
+                {recipes.map((recipe) => {
+                  const isSelected = selectedRecipes.some(r => r.recipe_id === recipe.recipe_id);
+                  return (
+                    <div
+                      key={recipe.recipe_id}
+                      className={`relative p-4 border rounded-lg transition-all ${
+                        isSelected 
+                          ? 'border-blue-500 bg-blue-50' 
+                          : 'border-gray-200 hover:shadow-lg hover:border-blue-300'
+                      }`}
+                    >
+                      <div className="absolute top-2 right-2">
+                        <input
+                          type="checkbox"
+                          checked={isSelected}
+                          onChange={() => handleMultiRecipeToggle(recipe)}
+                          className="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500"
+                          onClick={(e) => e.stopPropagation()}
+                        />
+                      </div>
+                      <div
+                        onClick={() => handleRecipeSelect(recipe)}
+                        className="cursor-pointer pr-8"
+                      >
+                        <h4 className="text-lg font-semibold text-gray-900 mb-2">
+                          {recipe.recipe_name}
+                        </h4>
+                        <div className="space-y-1 text-sm text-gray-600">
+                          <p>バッチサイズ: {recipe.batch_size} {recipe.batch_unit}</p>
+                          {recipe.yield_per_batch > 0 && (
+                            <p>出来高: {recipe.yield_per_batch} {recipe.yield_unit}</p>
+                          )}
+                          <p>複雑度: {recipe.complexity_level}</p>
+                          {recipe.category && (
+                            <p>カテゴリー: {recipe.category}</p>
+                          )}
+                        </div>
+                        <div className="mt-3">
+                          <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
+                            詳細原価計算
+                          </span>
+                        </div>
+                      </div>
                     </div>
-                    <div className="mt-3">
-                      <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
-                        原価計算
-                      </span>
-                    </div>
-                  </div>
-                ))}
+                  );
+                })}
               </div>
             )}
           </div>
         </div>
-      ) : (
+      )}
+
+      {viewMode === 'single' && selectedRecipe && (
         <div>
           {loading ? (
             <div className="flex justify-center items-center h-32">
@@ -118,6 +215,18 @@ const CostCalculationPage: React.FC = () => {
             </div>
           ) : (
             <CostCalculator recipe={selectedRecipe} recipeDetails={recipeDetails} />
+          )}
+        </div>
+      )}
+
+      {viewMode === 'comparison' && (
+        <div>
+          {loading ? (
+            <div className="flex justify-center items-center h-32">
+              <div className="text-sm text-gray-600">比較データを計算中...</div>
+            </div>
+          ) : (
+            <MultiRecipeCostComparison recipes={selectedRecipes} allRecipeDetails={allRecipeDetails} />
           )}
         </div>
       )}


### PR DESCRIPTION
- Create MultiRecipeCostComparison component for side-by-side comparison
- Add checkbox selection UI for multiple recipes
- Implement comparison mode with best value highlighting
- Support both batch cost and per-unit cost comparison
- Add mode switching between single recipe and multi-recipe comparison
- Include usage instructions and selection counter
- Maintain existing single recipe functionality

Features:
- Select multiple recipes with checkboxes
- Compare batch costs and per-unit costs side by side
- Highlight best values in green with bold text
- Toggle between single and comparison modes
- Clear instructions for user guidance

🤖 Generated with [Claude Code](https://claude.ai/code)